### PR TITLE
Add archive page and expand data

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This is a simple single page application built with Vue 3 and Vue Router. It dem
 - Course CRUD with modals
 - View student enrollments and course rosters
 - Enroll students in courses with grades
+- Archive/restore students
+- Courses include instructor information
 
 ## Getting Started
 Requires Node.js **20.19** or **22.12** or newer.

--- a/app/src/components/CourseModal.vue
+++ b/app/src/components/CourseModal.vue
@@ -20,6 +20,10 @@
               <label class="form-label">Credits</label>
               <input v-model.number="form.credits" type="number" class="form-control" required />
             </div>
+            <div class="mb-3">
+              <label class="form-label">Instructor</label>
+              <input v-model="form.instructor" class="form-control" required />
+            </div>
             <button type="submit" class="btn btn-primary">Save</button>
           </form>
         </div>
@@ -42,7 +46,8 @@ const form = reactive({
   id: '',
   name: '',
   code: '',
-  credits: 0
+  credits: 0,
+  instructor: ''
 })
 const modalRef = ref()
 let modal

--- a/app/src/components/Sidebar.vue
+++ b/app/src/components/Sidebar.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="d-flex flex-column p-3 text-bg-dark" style="width: 200px; height: 100vh;">
+    <img src="/vite.svg" alt="logo" width="40" class="mb-2" />
     <h4 class="text-white">SIS</h4>
     <ul class="nav nav-pills flex-column mb-auto">
       <li class="nav-item">
@@ -7,6 +8,9 @@
       </li>
       <li>
         <router-link class="nav-link text-white" to="/courses">Courses</router-link>
+      </li>
+      <li>
+        <router-link class="nav-link text-white" to="/archived">Archived</router-link>
       </li>
     </ul>
     <button class="btn btn-secondary mt-auto" @click="logout">Logout</button>

--- a/app/src/pages/Archived.vue
+++ b/app/src/pages/Archived.vue
@@ -1,0 +1,39 @@
+<template>
+  <Layout>
+    <h3 class="mb-3">Archived Students</h3>
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>First Name</th>
+          <th>Last Name</th>
+          <th>Email</th>
+          <th>Status</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="s in archived" :key="s.id">
+          <td>{{ s.firstName }}</td>
+          <td>{{ s.lastName }}</td>
+          <td>{{ s.email }}</td>
+          <td>{{ s.status }}</td>
+          <td>
+            <button class="btn btn-sm btn-secondary" @click="restore(s)">Restore</button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </Layout>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import Layout from '../components/Layout.vue'
+import store from '../store'
+
+const archived = computed(() => store.students.filter(s => s.status === 'Archived'))
+
+const restore = (s) => {
+  s.status = 'Active'
+}
+</script>

--- a/app/src/pages/CourseDetails.vue
+++ b/app/src/pages/CourseDetails.vue
@@ -3,6 +3,7 @@
     <div v-if="course">
       <h3>{{ course.name }} ({{ course.code }})</h3>
       <p>Credits: {{ course.credits }}</p>
+      <p>Instructor: {{ course.instructor }}</p>
 
       <h4 class="mt-4">Enrolled Students</h4>
       <table class="table">

--- a/app/src/pages/Login.vue
+++ b/app/src/pages/Login.vue
@@ -1,6 +1,7 @@
 <template>
-  <div class="container mt-5" style="max-width: 400px;">
-    <h3>Login</h3>
+  <div class="container mt-5 text-center" style="max-width: 400px;">
+    <img src="/vite.svg" alt="logo" width="80" class="mb-3" />
+    <h3>SIS Login</h3>
     <form @submit.prevent="login">
       <div class="mb-3">
         <label class="form-label">Username</label>

--- a/app/src/pages/Students.vue
+++ b/app/src/pages/Students.vue
@@ -44,6 +44,7 @@ const selected = ref(null)
 
 const filtered = computed(() => {
   return store.students.filter(s => {
+    if (s.status === 'Archived') return false
     return (
       s.firstName.toLowerCase().includes(search.value.toLowerCase()) ||
       s.lastName.toLowerCase().includes(search.value.toLowerCase())

--- a/app/src/router.js
+++ b/app/src/router.js
@@ -2,6 +2,7 @@ import { createRouter, createWebHistory } from 'vue-router'
 import Login from './pages/Login.vue'
 import Students from './pages/Students.vue'
 import StudentDetails from './pages/StudentDetails.vue'
+import Archived from './pages/Archived.vue'
 import Courses from './pages/Courses.vue'
 import CourseDetails from './pages/CourseDetails.vue'
 
@@ -15,6 +16,11 @@ const routes = [
   {
     path: '/students',
     component: Students,
+    meta: { requiresAuth: true }
+  },
+  {
+    path: '/archived',
+    component: Archived,
     meta: { requiresAuth: true }
   },
   {

--- a/app/src/store.js
+++ b/app/src/store.js
@@ -13,6 +13,42 @@ const store = reactive({
       address: 'Rruga B, Prishtina',
       enrollmentYear: 2022,
       status: 'Active'
+    },
+    {
+      id: 'stu002',
+      firstName: 'Donika',
+      lastName: 'Krasniqi',
+      dateOfBirth: '2002-03-22',
+      gender: 'Female',
+      email: 'donika.krasniqi@email.com',
+      phone: '+38344111223',
+      address: 'Dardania, Prishtina',
+      enrollmentYear: 2021,
+      status: 'Active'
+    },
+    {
+      id: 'stu003',
+      firstName: 'Blerim',
+      lastName: 'Hoxha',
+      dateOfBirth: '2001-05-08',
+      gender: 'Male',
+      email: 'blerim.hoxha@email.com',
+      phone: '+38344111224',
+      address: 'Ulqin, Kosovo',
+      enrollmentYear: 2020,
+      status: 'Archived'
+    },
+    {
+      id: 'stu004',
+      firstName: 'Elira',
+      lastName: 'Shala',
+      dateOfBirth: '2003-11-19',
+      gender: 'Female',
+      email: 'elira.shala@email.com',
+      phone: '+38344111225',
+      address: 'Peja, Kosovo',
+      enrollmentYear: 2022,
+      status: 'Active'
     }
   ],
   courses: [
@@ -21,7 +57,32 @@ const store = reactive({
       name: 'Introduction to Programming',
       code: 'CS101',
       description: 'Learn programming basics.',
-      credits: 4
+      credits: 4,
+      instructor: 'Prof. Ilir D'
+    },
+    {
+      id: 'crs002',
+      name: 'Data Structures',
+      code: 'CS102',
+      description: 'Introduction to data structures.',
+      credits: 4,
+      instructor: 'Prof. Vesa T'
+    },
+    {
+      id: 'crs003',
+      name: 'Algorithms',
+      code: 'CS201',
+      description: 'Algorithm design and analysis.',
+      credits: 4,
+      instructor: 'Prof. Ardit B'
+    },
+    {
+      id: 'crs004',
+      name: 'Databases',
+      code: 'CS202',
+      description: 'Relational database design.',
+      credits: 3,
+      instructor: 'Prof. Leutrim H'
     }
   ],
   enrollments: [
@@ -31,6 +92,27 @@ const store = reactive({
       courseId: 'crs001',
       semester: 'Fall 2024',
       grade: 'A'
+    },
+    {
+      id: 'enr002',
+      studentId: 'stu002',
+      courseId: 'crs002',
+      semester: 'Fall 2024',
+      grade: ''
+    },
+    {
+      id: 'enr003',
+      studentId: 'stu003',
+      courseId: 'crs003',
+      semester: 'Spring 2024',
+      grade: 'B'
+    },
+    {
+      id: 'enr004',
+      studentId: 'stu004',
+      courseId: 'crs001',
+      semester: 'Fall 2024',
+      grade: ''
     }
   ]
 })


### PR DESCRIPTION
## Summary
- extend sample data for students and courses
- add instructor field on courses and show on course details
- create a page for archived students and filter them out of active list
- include link and logo in sidebar and brand login screen
- update router and README

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686e93498f188326b6fc0b60cacef96a