### PR TITLE
Improve login, enrollment and course management

### DIFF
--- a/app/src/components/EnrollmentModal.vue
+++ b/app/src/components/EnrollmentModal.vue
@@ -18,10 +18,6 @@
               <label class="form-label">Semester</label>
               <input v-model="form.semester" class="form-control" required />
             </div>
-            <div class="mb-3">
-              <label class="form-label">Grade</label>
-              <input v-model="form.grade" class="form-control" />
-            </div>
             <button type="submit" class="btn btn-primary">Save</button>
           </form>
         </div>
@@ -43,8 +39,7 @@ const emit = defineEmits(['update:modelValue', 'save'])
 
 const form = reactive({
   courseId: '',
-  semester: '',
-  grade: ''
+  semester: ''
 })
 
 const modalRef = ref()
@@ -58,7 +53,6 @@ const show = () => {
   if (!modal) modal = new bootstrap.Modal(modalRef.value)
   form.courseId = store.courses[0]?.id || ''
   form.semester = ''
-  form.grade = ''
   modal.show()
 }
 

--- a/app/src/components/Sidebar.vue
+++ b/app/src/components/Sidebar.vue
@@ -10,6 +10,9 @@
         <router-link class="nav-link text-white" to="/courses">Courses</router-link>
       </li>
       <li>
+        <router-link class="nav-link text-white" to="/instructors">Instructors</router-link>
+      </li>
+      <li>
         <router-link class="nav-link text-white" to="/archived">Archived</router-link>
       </li>
     </ul>

--- a/app/src/pages/CourseDetails.vue
+++ b/app/src/pages/CourseDetails.vue
@@ -18,7 +18,7 @@
           <tr v-for="e in courseEnrollments" :key="e.id">
             <td>{{ studentName(e.studentId) }}</td>
             <td>{{ e.semester }}</td>
-            <td>{{ e.grade }}</td>
+            <td>{{ e.grade || '-' }}</td>
           </tr>
         </tbody>
       </table>

--- a/app/src/pages/Courses.vue
+++ b/app/src/pages/Courses.vue
@@ -15,7 +15,7 @@
         </tr>
       </thead>
       <tbody>
-        <tr v-for="c in filtered" :key="c.id">
+        <tr v-for="c in paginated" :key="c.id">
           <td><router-link :to="`/courses/${c.id}`">{{ c.name }}</router-link></td>
           <td>{{ c.code }}</td>
           <td>{{ c.credits }}</td>
@@ -26,23 +26,46 @@
         </tr>
       </tbody>
     </table>
+    <nav aria-label="Course pages" class="mt-2">
+      <ul class="pagination justify-content-center">
+        <li class="page-item" :class="{ disabled: page === 1 }">
+          <button class="page-link" @click="page--" :disabled="page === 1">Previous</button>
+        </li>
+        <li class="page-item" :class="{ disabled: page === totalPages }">
+          <button class="page-link" @click="page++" :disabled="page === totalPages">Next</button>
+        </li>
+      </ul>
+    </nav>
     <CourseModal v-model="modalOpen" :course="selected" @save="save" />
   </Layout>
 </template>
 
 <script setup>
-import { ref, computed, defineAsyncComponent } from 'vue'
+import { ref, computed, watch, defineAsyncComponent } from 'vue'
 import Layout from '../components/Layout.vue'
 import store from '../store'
 
 const search = ref('')
 const modalOpen = ref(false)
 const selected = ref(null)
+const page = ref(1)
+const pageSize = 10
 
 const CourseModal = defineAsyncComponent(() => import('../components/CourseModal.vue'))
 
-const filtered = computed(() => {
+const filteredCourses = computed(() => {
   return store.courses.filter(c => c.name.toLowerCase().includes(search.value.toLowerCase()))
+})
+
+const totalPages = computed(() => Math.ceil(filteredCourses.value.length / pageSize))
+
+const paginated = computed(() => {
+  const start = (page.value - 1) * pageSize
+  return filteredCourses.value.slice(start, start + pageSize)
+})
+
+watch(filteredCourses, () => {
+  if (page.value > totalPages.value) page.value = totalPages.value || 1
 })
 
 const openModal = () => {

--- a/app/src/pages/Instructors.vue
+++ b/app/src/pages/Instructors.vue
@@ -1,0 +1,21 @@
+<template>
+  <Layout>
+    <h3 class="mb-3">Instructors</h3>
+    <ul class="list-group">
+      <li v-for="i in instructors" :key="i" class="list-group-item">
+        {{ i }}
+      </li>
+    </ul>
+  </Layout>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import Layout from '../components/Layout.vue'
+import store from '../store'
+
+const instructors = computed(() => {
+  const names = new Set(store.courses.map(c => c.instructor))
+  return Array.from(names)
+})
+</script>

--- a/app/src/pages/Login.vue
+++ b/app/src/pages/Login.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container mt-5 text-center" style="max-width: 400px;">
+  <div class="container mt-5 mx-auto text-start" style="max-width: 400px;">
     <img src="/vite.svg" alt="logo" width="80" class="mb-3" />
     <h3>SIS Login</h3>
     <form @submit.prevent="login">

--- a/app/src/pages/StudentDetails.vue
+++ b/app/src/pages/StudentDetails.vue
@@ -1,6 +1,7 @@
 <template>
   <Layout>
     <div v-if="student">
+      <router-link to="/students" class="btn btn-link p-0 mb-2">Back</router-link>
       <h3>{{ student.firstName }} {{ student.lastName }}</h3>
       <p>Email: {{ student.email }}</p>
       <p>Status: {{ student.status }}</p>
@@ -19,7 +20,7 @@
           <tr v-for="e in studentEnrollments" :key="e.id">
             <td>{{ courseName(e.courseId) }}</td>
             <td>{{ e.semester }}</td>
-            <td>{{ e.grade }}</td>
+            <td>{{ e.grade || '-' }}</td>
           </tr>
         </tbody>
       </table>

--- a/app/src/router.js
+++ b/app/src/router.js
@@ -5,6 +5,7 @@ import StudentDetails from './pages/StudentDetails.vue'
 import Archived from './pages/Archived.vue'
 import Courses from './pages/Courses.vue'
 import CourseDetails from './pages/CourseDetails.vue'
+import Instructors from './pages/Instructors.vue'
 
 const routes = [
   { path: '/login', component: Login },
@@ -36,6 +37,11 @@ const routes = [
   {
     path: '/courses/:id',
     component: CourseDetails,
+    meta: { requiresAuth: true }
+  },
+  {
+    path: '/instructors',
+    component: Instructors,
     meta: { requiresAuth: true }
   },
 ]

--- a/app/src/store.js
+++ b/app/src/store.js
@@ -83,6 +83,86 @@ const store = reactive({
       description: 'Relational database design.',
       credits: 3,
       instructor: 'Prof. Leutrim H'
+    },
+    {
+      id: 'crs005',
+      name: 'Operating Systems',
+      code: 'CS203',
+      description: 'Processes, threads and memory management.',
+      credits: 4,
+      instructor: 'Prof. Lura K'
+    },
+    {
+      id: 'crs006',
+      name: 'Computer Networks',
+      code: 'CS204',
+      description: 'Network architectures and protocols.',
+      credits: 3,
+      instructor: 'Prof. Arber M'
+    },
+    {
+      id: 'crs007',
+      name: 'Software Engineering',
+      code: 'CS205',
+      description: 'Software development methodologies.',
+      credits: 3,
+      instructor: 'Prof. Nora B'
+    },
+    {
+      id: 'crs008',
+      name: 'Web Development',
+      code: 'CS206',
+      description: 'Building modern web applications.',
+      credits: 3,
+      instructor: 'Prof. Blerim R'
+    },
+    {
+      id: 'crs009',
+      name: 'Mobile App Development',
+      code: 'CS207',
+      description: 'Creating apps for mobile devices.',
+      credits: 3,
+      instructor: 'Prof. Luljeta P'
+    },
+    {
+      id: 'crs010',
+      name: 'Artificial Intelligence',
+      code: 'CS301',
+      description: 'Introduction to AI concepts.',
+      credits: 4,
+      instructor: 'Prof. Ardit B'
+    },
+    {
+      id: 'crs011',
+      name: 'Machine Learning',
+      code: 'CS302',
+      description: 'Supervised and unsupervised learning.',
+      credits: 4,
+      instructor: 'Prof. Vesa T'
+    },
+    {
+      id: 'crs012',
+      name: 'Computer Graphics',
+      code: 'CS303',
+      description: 'Rendering and graphics programming.',
+      credits: 3,
+      instructor: 'Prof. Ilir D'
+    },
+    {
+      id: 'crs013',
+      name: 'Cybersecurity',
+      code: 'CS304',
+      description: 'Principles of computer security.',
+      credits: 3,
+      instructor: 'Prof. Leutrim H'
+    },
+    {
+      id: 'crs014',
+      name: 'Cloud Computing',
+      code: 'CS305',
+      description: 'Cloud service models and architectures.',
+      credits: 3,
+      instructor: 'Prof. Arber M'
     }
   ],
   enrollments: [


### PR DESCRIPTION
## Summary
- left align login form
- add Back link to student profile
- prevent entering grade on enrollment
- paginate the courses list and add more CS classes
- show unique instructors and link from sidebar

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686e9a12dc148326a97107930ccfb4d6